### PR TITLE
Add buy and sell api methods with shop argument

### DIFF
--- a/src/main/java/api/regalowl/hyperconomy/HyperObjectAPI.java
+++ b/src/main/java/api/regalowl/hyperconomy/HyperObjectAPI.java
@@ -409,6 +409,16 @@ public class HyperObjectAPI implements ObjectAPI {
 		pt.setAmount(amount);
 		return hp.processTransaction(pt);
 	}
+
+	public TransactionResponse buy(Player p, HyperObject o, int amount, Shop shop) {
+		HyperConomy hc = HyperConomy.hc;
+		HyperPlayer hp = hc.getEconomyManager().getHyperPlayer(p.getName());
+		PlayerTransaction pt = new PlayerTransaction(TransactionType.BUY);
+		pt.setHyperObject(o);
+		pt.setAmount(amount);
+		pt.setTradePartner(shop.getOwner());
+		return hp.processTransaction(pt);
+	}
 	
 	public TransactionResponse sell(Player p, HyperObject o, int amount ) {
 		HyperConomy hc = HyperConomy.hc;
@@ -416,6 +426,16 @@ public class HyperObjectAPI implements ObjectAPI {
 		PlayerTransaction pt = new PlayerTransaction(TransactionType.SELL);
 		pt.setHyperObject(o);
 		pt.setAmount(amount);
+		return hp.processTransaction(pt);
+	}
+	
+	public TransactionResponse sell(Player p, HyperObject o, int amount, Shop shop) {
+		HyperConomy hc = HyperConomy.hc;
+		HyperPlayer hp = hc.getEconomyManager().getHyperPlayer(p.getName());
+		PlayerTransaction pt = new PlayerTransaction(TransactionType.SELL);
+		pt.setHyperObject(o);
+		pt.setAmount(amount);
+		pt.setTradePartner(shop.getOwner());
 		return hp.processTransaction(pt);
 	}
 

--- a/src/main/java/api/regalowl/hyperconomy/ObjectAPI.java
+++ b/src/main/java/api/regalowl/hyperconomy/ObjectAPI.java
@@ -250,10 +250,14 @@ public interface ObjectAPI
 	public ArrayList<HyperObject> getEnchantmentHyperObjects(ItemStack stack, String player);
 	
 	public TransactionResponse buy(Player p, HyperObject o, int amount);
+	public TransactionResponse buy(Player p, HyperObject o, int amount, Shop shop);
+	
+	public TransactionResponse sell(Player p, HyperObject o, int amount);
+	public TransactionResponse sell(Player p, HyperObject o, int amount, Shop shop);
 	
 	public TransactionResponse sellAll(Player p);
-	
 	public TransactionResponse sellAll(Player p, Inventory inventory);
+
 	
 	
 	public ArrayList<HyperObject> getAvailableObjects(String shopname);


### PR DESCRIPTION
This commit adds a shop argument to Buy and Sell HyperObjectAPI methods so that PlayerTransaction.setTradePartner() can be used. Tested and working as far as I can tell.
