### PR TITLE
Hc dev

### DIFF
--- a/src/main/java/api/regalowl/hyperconomy/HyperObjectAPI.java
+++ b/src/main/java/api/regalowl/hyperconomy/HyperObjectAPI.java
@@ -10,6 +10,7 @@ import org.bukkit.inventory.ItemStack;
 import regalowl.databukkit.CommonFunctions;
 
 public class HyperObjectAPI implements ObjectAPI {
+	@Deprecated
 	public double getTheoreticalPurchasePrice(int id, int durability, int amount, String economy) {
 		if (economy == null) {
 			economy = "default";
@@ -17,8 +18,8 @@ public class HyperObjectAPI implements ObjectAPI {
 		HyperConomy hc = HyperConomy.hc;
 		CommonFunctions cf = hc.gCF();
 		HyperEconomy he = hc.getEconomyManager().getEconomy(economy);
-		@SuppressWarnings("deprecation")
-		ItemStack stack = new ItemStack(id, 1);
+		//@SuppressWarnings("deprecation")
+		ItemStack stack = new ItemStack(id);
 		stack.setDurability((short) durability);
 		HyperItem ho = he.getHyperItem(stack);
 		if (ho == null) {
@@ -29,14 +30,14 @@ public class HyperObjectAPI implements ObjectAPI {
 		return price;
 	}
 	
-	public double getTheoreticalPurchasePrice(Material type, short durability, int amount, String economy) {
+	public double getTheoreticalPurchasePrice(Material material, short durability, int amount, String economy) {
 		if (economy == null) {
 			economy = "default";
 		}
 		HyperConomy hc = HyperConomy.hc;
 		CommonFunctions cf = hc.gCF();
 		HyperEconomy he = hc.getEconomyManager().getEconomy(economy);
-		ItemStack stack = new ItemStack(type, 1);
+		ItemStack stack = new ItemStack(material);
 		stack.setDurability(durability);
 		HyperItem ho = he.getHyperItem(stack);
 		if (ho == null) {
@@ -46,7 +47,8 @@ public class HyperObjectAPI implements ObjectAPI {
 		price = cf.twoDecimals(price);
 		return price;
 	}
-
+	
+	@Deprecated
 	public double getTheoreticalSaleValue(int id, int durability, int amount, String economy) {
 		if (economy == null) {
 			economy = "default";
@@ -54,8 +56,8 @@ public class HyperObjectAPI implements ObjectAPI {
 		HyperConomy hc = HyperConomy.hc;
 		CommonFunctions cf = hc.gCF();
 		HyperEconomy he = hc.getEconomyManager().getEconomy(economy);
-		@SuppressWarnings("deprecation")
-		ItemStack stack = new ItemStack(id, 1);
+		//@SuppressWarnings("deprecation")
+		ItemStack stack = new ItemStack(id);
 		stack.setDurability((short) durability);
 		HyperItem ho = he.getHyperItem(stack);
 		if (ho == null) {
@@ -66,6 +68,25 @@ public class HyperObjectAPI implements ObjectAPI {
 		return value;
 	}
 
+	public double getTheoreticalSaleValue(Material material, short durability, int amount, String economy) {
+		if (economy == null) {
+			economy = "default";
+		}
+		HyperConomy hc = HyperConomy.hc;
+		CommonFunctions cf = hc.gCF();
+		HyperEconomy he = hc.getEconomyManager().getEconomy(economy);
+		ItemStack stack = new ItemStack(material);
+		stack.setDurability(durability);
+		HyperItem ho = he.getHyperItem(stack);
+		if (ho == null) {
+			return 0.0;
+		}
+		Double value = ho.getValue(amount);
+		value = cf.twoDecimals(value);
+		return value;
+	}
+	
+    @Deprecated
 	public double getTruePurchasePrice(int id, int durability, int amount, String economy) {
 		if (economy == null) {
 			economy = "default";
@@ -73,8 +94,8 @@ public class HyperObjectAPI implements ObjectAPI {
 		HyperConomy hc = HyperConomy.hc;
 		CommonFunctions cf = hc.gCF();
 		HyperEconomy he = hc.getEconomyManager().getEconomy(economy);
-		@SuppressWarnings("deprecation")
-		ItemStack stack = new ItemStack(id, 1);
+		//@SuppressWarnings("deprecation")
+		ItemStack stack = new ItemStack(id);
 		stack.setDurability((short) durability);
 		HyperItem ho = he.getHyperItem(stack);
 		if (ho == null) {
@@ -86,13 +107,35 @@ public class HyperObjectAPI implements ObjectAPI {
 		price = cf.twoDecimals(price);
 		return price;
 	}
+    
+    public double getTruePurchasePrice(Material material, short durability, int amount, String economy) {
+		if (economy == null) {
+			economy = "default";
+		}
+		HyperConomy hc = HyperConomy.hc;
+		CommonFunctions cf = hc.gCF();
+		HyperEconomy he = hc.getEconomyManager().getEconomy(economy);
+		//@SuppressWarnings("deprecation")
+		ItemStack stack = new ItemStack(material);
+		stack.setDurability(durability);
+		HyperItem ho = he.getHyperItem(stack);
+		if (ho == null) {
+			return 0.0;
+		}
+		Double price = ho.getCost(amount);
+		double tax = ho.getPurchaseTax(price);
+		price = tax + price;
+		price = cf.twoDecimals(price);
+		return price;
+	}
 
+    @Deprecated
 	public double getTrueSaleValue(int id, int durability, int amount, Player player) {
 		HyperConomy hc = HyperConomy.hc;
 		CommonFunctions cf = hc.gCF();
 		HyperEconomy he = hc.getEconomyManager().getHyperPlayer(player.getName()).getHyperEconomy();
-		@SuppressWarnings("deprecation")
-		ItemStack stack = new ItemStack(id, 1);
+		//@SuppressWarnings("deprecation")
+		ItemStack stack = new ItemStack(id);
 		stack.setDurability((short) durability);
 		HyperItem ho = he.getHyperItem(stack);
 		if (ho == null) {
@@ -106,13 +149,12 @@ public class HyperObjectAPI implements ObjectAPI {
 		return value;
 	}
 	
-	public double getTrueSaleValue(int id, int durability, int amount, Player player, String economy) {
+	public double getTrueSaleValue(Material material, short durability, int amount, Player player, String economy) {
 		HyperConomy hc = HyperConomy.hc;
 		CommonFunctions cf = hc.gCF();
 		HyperEconomy he = hc.getEconomyManager().getEconomy(economy);
-		@SuppressWarnings("deprecation")
-		ItemStack stack = new ItemStack(id, 1);
-		stack.setDurability((short) durability);
+		ItemStack stack = new ItemStack(material);
+		stack.setDurability(durability);
 		HyperItem ho = he.getHyperItem(stack);
 		if (ho == null) {
 			return 0.0;

--- a/src/main/java/api/regalowl/hyperconomy/ObjectAPI.java
+++ b/src/main/java/api/regalowl/hyperconomy/ObjectAPI.java
@@ -2,6 +2,7 @@ package regalowl.hyperconomy;
 
 import java.util.ArrayList;
 
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -29,6 +30,26 @@ public interface ObjectAPI
 	@Deprecated
 	double getTheoreticalPurchasePrice(int id, int durability, int amount, String nameOfEconomy);
 
+	
+	/**
+	 * 
+	 * @param material
+	 *            The Material of an item, enchantment, or custom object.
+	 * @param damageValue
+	 *            The durability value of an item, enchantment, or custom
+	 *            object.
+	 * @param amount
+	 *            The amount of the object.
+	 * @param nameOfEconomy
+	 *            The name of the economy that the object is a part of. Put
+	 *            "default" if SQL is not used or to specify the default
+	 *            economy.
+	 * @return The sale value of an object ignoring durability, tax, and all
+	 *         price modifiers.
+	 */
+	double getTheoreticalPurchasePrice(Material material, short durability, int amount, String nameOfEconomy);
+
+	
 	/**
 	 * 
 	 * @param id
@@ -47,7 +68,27 @@ public interface ObjectAPI
 	 */
 	@Deprecated
 	double getTheoreticalSaleValue(int id, int durability, int amount, String nameOfEconomy);
-
+	
+	
+	/**
+	 * 
+	 * @param material
+	 *            The Material of an item, enchantment, or custom object.
+	 * @param damageValue
+	 *            The durability value of an item, enchantment, or custom
+	 *            object.
+	 * @param amount
+	 *            The amount of the object.
+	 * @param nameOfEconomy
+	 *            The name of the economy that the object is a part of. Put
+	 *            "default" if SQL is not used or to specify the default
+	 *            economy.
+	 * @return The sale value of an object ignoring durability, tax, and all
+	 *         price modifiers.
+	 */
+	double getTheoreticalSaleValue(Material material, short durability, int amount, String nameOfEconomy);
+	
+	
 	/**
 	 * 
 	 * @param id
@@ -66,7 +107,27 @@ public interface ObjectAPI
 	 */
 	@Deprecated
 	double getTruePurchasePrice(int id, int durability, int amount, String nameOfEconomy);
+	
+	
+	/**
+	 * 
+	 * @param material
+	 *            The Material of an item, enchantment, or custom object.
+	 * @param damageValue
+	 *            The durability value of an item, enchantment, or custom
+	 *            object.
+	 * @param amount
+	 *            The amount of the object.
+	 * @param nameOfEconomy
+	 *            The name of the economy that the object is a part of. Put
+	 *            "default" if SQL is not used or to specify the default
+	 *            economy.
+	 * @return The purchase price of an object including taxes and all price
+	 *         modifiers.
+	 */
+	double getTruePurchasePrice(Material material, short durability, int amount, String nameOfEconomy);
 
+	
 	/**
 	 * 
 	 * @param id
@@ -81,8 +142,29 @@ public interface ObjectAPI
 	 * @return The sale value of an object including all taxes, durability, and
 	 *         price modifiers.
 	 */
-
+	@Deprecated
 	double getTrueSaleValue(int id, int durability, int amount, Player player);
+	
+	
+	/**
+	 * 
+	 * @param material
+	 *            The Material of an item, enchantment, or custom object.
+	 * @param damageValue
+	 *            The durability value of an item, enchantment, or custom
+	 *            object.
+	 * @param amount
+	 *            The amount of the object.
+	 * @param player
+	 *            The player that is selling the object, item, or enchantment.
+	 * @param nameOfEconomy
+	 *            The name of the economy that the object is a part of. Put
+	 *            "default" if SQL is not used or to specify the default
+	 *            economy.
+	 * @return The sale value of an object including all taxes, durability, and
+	 *         price modifiers.
+	 */
+	double getTrueSaleValue(Material material, short durability, int amount, Player player, String nameOfEconomy);
 	
 	double getTruePurchasePrice(HyperObject hyperObject, EnchantmentClass enchantClass, int amount);
 


### PR DESCRIPTION
This pull request makes changes to the ObjectAPI interface and HyperObjectAPI class.

I've deprecated methods that use the deprecated ItemStack(int id, int amount) calls and added new methods that use ItemStack(Material material).

**_I removed the old calls that initiated an item stack with "int durability" in the "int amount" argument.**_

For the updated method of getTrueSaleValue() I added an extra argument "String economy" so the method is not limited to using the players economy.
