### PR TITLE
Allow selling of composite items that are partly inital

### DIFF
--- a/src/main/java/hyperobjects/regalowl/hyperconomy/CompositeItem.java
+++ b/src/main/java/hyperobjects/regalowl/hyperconomy/CompositeItem.java
@@ -286,9 +286,11 @@ public class CompositeItem extends BasicObject implements HyperItem {
 		for (Map.Entry<HyperItem,Double> entry : components.entrySet()) {
 		    HyperObject ho = entry.getKey();
 		    Double qty = entry.getValue();
-		    int ci = (int) Math.floor(ho.getMaxInitial() / qty);
-		    if (ci < maxInitial) {
-		    	maxInitial = ci;
+		    if (Boolean.parseBoolean(ho.getInitiation())) {
+			int ci = (int) Math.floor(ho.getMaxInitial() / qty);
+			if (ci < maxInitial) {
+			    maxInitial = ci;
+			}
 		    }
 		}
 		return maxInitial;


### PR DESCRIPTION
I had the problem that I couldn't sell items when they were based on composite items, that are not all in initiation mode.

Example:

Logs, not initiation mode, more than median available
Diamonds, initiation mode, a few available

Selling a diamond sword resulted in selling 0 swords
